### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/oc-2/python-app/security/code-scanning/1](https://github.com/oc-2/python-app/security/code-scanning/1)

The best fix is to add a `permissions:` block specifying the least privileges required for the workflow. Since none of the steps in this workflow require write permissions (they only check out code, install dependencies, and run tests), specifying `contents: read` as the only permission is sufficient. The permissions block should be placed at the workflow root (above `jobs:`), so it applies to all jobs in the workflow. No additional methods or imports are required; the change is a single line addition to the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
